### PR TITLE
[idea] Move all intercepted methods to a shared module

### DIFF
--- a/spec/shared_interception_module_spec.rb
+++ b/spec/shared_interception_module_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'MethodInterceptor module' do
+  describe 'is namespaced under the class' do
+    subject { Model }
+
+    it do
+      expect(subject.ancestors).to include Model::MethodInterceptor
+    end
+  end
+
+  describe 'lists the methods it owns' do
+    subject { Model::MethodInterceptor }
+
+    it do
+      expect(subject.to_s).to eq 'MethodInterceptor(save, create)'
+    end
+
+    describe 'even when reopened and re-intercepted' do
+      before do
+        class Model
+          intercept(:build) { true }
+
+          def build
+            :build
+          end
+        end
+      end
+
+      subject { Model::MethodInterceptor }
+
+      it { expect(subject.to_s).to eq 'MethodInterceptor(save, create, build)' }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,6 @@ CodeClimate::TestReporter.start
 
 require "pry"
 
-["simplecov", "repository"].each do |file|
-  require File.dirname(__FILE__) + "/support/#{file}"
+["simplecov", "repository", "model"].each do |file|
+  require File.join(File.dirname(__FILE__), "support" , file)
 end

--- a/spec/support/model.rb
+++ b/spec/support/model.rb
@@ -1,0 +1,21 @@
+require 'interceptor'
+
+class Model
+  extend Interceptor
+
+  intercept :save do |_attrs|
+    true
+  end
+
+  intercept :create do |_attrs|
+    true
+  end
+
+  def save(attributes)
+    attributes
+  end
+
+  def create(attributes)
+    attributes
+  end
+end


### PR DESCRIPTION
This applies a thing I learned watching RubyTapas.

It makes the interceptor module for each class become a single module, and all intercepted methods are defined in that module.
## Compare

Given a model class

``` ruby
require 'interceptor'

class Model
  extend Interceptor

  intercept :save do |_attrs|
    true
  end

  intercept :create do |_attrs|
    true
  end

  def save(attributes)
    attributes
  end

  def create(attributes)
    attributes
  end
end
```
### Master

``` ruby
# => pp Model.ancestors
[Model::CreateMethodInterceptor,
 Model::SaveMethodInterceptor,
 Model,
 Object,
 PP::ObjectMixin,
 Kernel,
 BasicObject]
```
### PR

``` ruby
# =>  pp Model.ancestors
[Model::MethodInterceptor,
 Model,
 Object,
 PP::ObjectMixin,
 Kernel,
 BasicObject]
# => Model.ancestors.first.to_s
"MethodInterceptor(save, create)"
```
